### PR TITLE
Improve CSV load resiliency in analytics views

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -23,6 +23,22 @@ def extract_name(title):
         return title
 
 
+def load_csv_data(context, user, filename, usecols):
+    csv_file_obj = Csv.objects.filter(
+        user=user, csv_file__icontains=filename).first()
+    if not csv_file_obj:
+        context['error_message'] = (
+            f"No uploaded data found for {filename}. Please upload the file and try again.")
+        return None
+
+    try:
+        return pd.read_csv(csv_file_obj.csv_file.path, usecols=usecols)
+    except (FileNotFoundError, pd.errors.EmptyDataError) as exc:
+        context['error_message'] = (
+            f"Unable to read {filename}: {exc}. Please re-upload the file and try again.")
+        return None
+
+
 class CsvAnalyticsView(TemplateView):
     def get_template_names(self):
         filename = self.kwargs.get('filename')
@@ -68,10 +84,9 @@ class ProfilesAnalytics:
             'Profile Name', 'Profile Creation Time', 'Maturity Level', 'Primary Lang']
 
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='Profiles.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'Profiles.csv', selected_columns)
+        if df is None:
+            return context
         table_data = df.to_dict('records')
 
         # Add the data to the context
@@ -87,10 +102,9 @@ class BillingHistoryAnalytics:
         plot_title = 'Gross Sale Amount by Currency and Payment Status'
 
         # Get the data from the CSV file
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='BillingHistory.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'BillingHistory.csv', selected_columns)
+        if df is None:
+            return context
 
         # remove NaN values and duplicates
         clean_df = df.dropna().drop_duplicates()
@@ -140,10 +154,9 @@ class MyListAnalytics:
         selected_columns = ["Profile Name", "Title Name", "Utc Title Add Date"]
 
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='MyList.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'MyList.csv', selected_columns)
+        if df is None:
+            return context
         clean_df = df.dropna().drop_duplicates()
         table_data = clean_df.to_dict('records')
         context['table_data'] = table_data
@@ -157,10 +170,9 @@ class ProfilesTotalWatchTimeAnalytics:
                             "Duration", "Title", "Device Type"]
 
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='ViewingActivity.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'ViewingActivity.csv', selected_columns)
+        if df is None:
+            return context
         df['Duration'] = pd.to_timedelta(df['Duration'])
         df['Start Time'] = pd.to_datetime(df['Start Time'])
         df['Date'] = df['Start Time'].dt.date
@@ -205,10 +217,9 @@ class Top3MostWatchedAnalytics:
                             "Duration", "Title", "Device Type"]
 
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='ViewingActivity.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'ViewingActivity.csv', selected_columns)
+        if df is None:
+            return context
         df['Duration'] = pd.to_timedelta(df['Duration'])
         df['Start Time'] = pd.to_datetime(df['Start Time'])
         df['Date'] = df['Start Time'].dt.date
@@ -268,10 +279,9 @@ class Top3DaysAnalytics:
         selected_columns = ["Profile Name", "Start Time",
                             "Duration", "Title", "Device Type"]
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='ViewingActivity.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'ViewingActivity.csv', selected_columns)
+        if df is None:
+            return context
         df['Duration'] = pd.to_timedelta(df['Duration'])
         df['Start Time'] = pd.to_datetime(df['Start Time'])
         df['Date'] = df['Start Time'].dt.date
@@ -329,10 +339,9 @@ class TopDaysAnalytics:
         selected_columns = ["Profile Name", "Start Time",
                             "Duration", "Title", "Device Type"]
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='ViewingActivity.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'ViewingActivity.csv', selected_columns)
+        if df is None:
+            return context
         df['Duration'] = pd.to_timedelta(df['Duration'])
         df['Start Time'] = pd.to_datetime(df['Start Time'])
         df['Day of Week'] = df['Start Time'].dt.day_name()
@@ -391,10 +400,9 @@ class TopHoursAnalytics:
         selected_columns = ["Profile Name", "Start Time",
                             "Duration", "Title", "Device Type"]
         # Get the table data
-        csv_file_obj = Csv.objects.filter(
-            user=user, csv_file__icontains='ViewingActivity.csv').first()
-        csv_file_path = csv_file_obj.csv_file.path
-        df = pd.read_csv(csv_file_path, usecols=selected_columns)
+        df = load_csv_data(context, user, 'ViewingActivity.csv', selected_columns)
+        if df is None:
+            return context
         df['Duration'] = pd.to_timedelta(df['Duration'])
         df['Start Time'] = pd.to_datetime(df['Start Time'])
         df['Hour Interval'] = pd.cut(df['Start Time'].dt.hour, bins=[


### PR DESCRIPTION
### Motivation
- Prevent analytics views from crashing when expected uploaded CSVs are missing or empty. 
- Consolidate repeated CSV query/read logic into a single helper to make error handling consistent across charts and tables.

### Description
- Add a new helper `load_csv_data(context, user, filename, usecols)` that locates the user's uploaded `Csv`, reads the file with `pandas.read_csv`, and sets a friendly `context['error_message']` on failure.
- Replace direct `Csv.objects.filter(...).first()` + `pd.read_csv(...)` calls in `ProfilesAnalytics`, `BillingHistoryAnalytics`, `MyListAnalytics`, `ProfilesTotalWatchTimeAnalytics`, `Top3MostWatchedAnalytics`, `Top3DaysAnalytics`, `TopDaysAnalytics`, and `TopHoursAnalytics` with the shared loader and return early if it returns `None`.
- Keep existing plotting and context population behavior unchanged when data is available, while avoiding unhandled `FileNotFoundError`/`EmptyDataError` scenarios.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cd2fd530832fa1d15ecc649eaef9)